### PR TITLE
change split_at and split_from behavior to normalize whitespace and deal with mixed whitespace

### DIFF
--- a/pyisc/dhcpd/utils.py
+++ b/pyisc/dhcpd/utils.py
@@ -28,7 +28,7 @@ class DhcpdSplitter(TokenSplitter):
         separated by a comma)
 
         """
-        return split_at(self.token.value[:-1], ' ', 2)
+        return split_at(self.token.value[:-1], 2)
 
     def parameter_boolean(self):
         """Return a list of the supplied string
@@ -74,7 +74,7 @@ class DhcpdSplitter(TokenSplitter):
         semicolon.
 
         """
-        return split_from(self.token.value[:-1], ' ', 2)
+        return split_from(self.token.value[:-1], 2)
 
     def parameter_general(self):
         """Return a list from a general parameter string.
@@ -92,7 +92,7 @@ class DhcpdSplitter(TokenSplitter):
         left curly bracket.
 
         """
-        return split_from(self.token.value[:-1].strip(), ' ', 2)
+        return split_from(self.token.value[:-1].strip(), 2)
 
     def declaration_general(self):
         """Return a list from a general declaration string.

--- a/pyisc/shared/utils.py
+++ b/pyisc/shared/utils.py
@@ -15,6 +15,8 @@
 """General helper functions and classes for the module."""
 
 import copy
+import shlex
+
 from pyisc.shared.nodes import Node, PropertyNode
 
 
@@ -65,13 +67,13 @@ class TokenSplitter:
         return getattr(self, str(token.type), lambda: default)() + [None, None]
 
 
-def split_at(string, sep, pos):
+def split_at(string, pos):
     """
-    Return string splitted at the desired separator.
+    Return string splitted at the desired separator.  Whitespace is normalized,
+         except in quoted strings
 
     Args:
         string (str): The supplied string that will be splitted.
-        sep (str): The desired separator to use for the split.
         pos (int): The desired occurence of the defined separator
             within the supplied string and hence the point of the split
             operation.
@@ -81,21 +83,21 @@ def split_at(string, sep, pos):
 
     Examples:
         >>> isc_string = 'option domain-name "example.org";'
-        >>> shared.utils.split_at(isc_string, ' ', 2)
+        >>> shared.utils.split_at(isc_string, 2)
         ['option domain-name', '"example.org";']
 
     """
-    string = string.split(sep)
-    return [sep.join(string[:pos]), sep.join(string[pos:])]
+    string = shlex.split(string, posix=False)
+    return [' '.join(string[:pos]), ' '.join(string[pos:])]
 
 
-def split_from(string, sep, pos):
+def split_from(string, pos):
     """
-    Return string splitted from the desired separator.
+    Return string splitted from the desired separator.  Whitespace is normalized.
+         except in quoted strings
 
     Args:
         string (str): The supplied string that will be splitted.
-        sep (str): The desired separator to use for the split.
         pos (int): The desired first occurence of the defined separator
             within the supplied string. This will be the position of
             the first split performed.
@@ -105,12 +107,12 @@ def split_from(string, sep, pos):
 
     Examples:
         >>> isc_string = 'failover peer "dhcpd-failover" state'
-        >>> shared.utils.split_from(isc_string, ' ', 2)
+        >>> shared.utils.split_from(isc_string, 2)
         ['failover peer', '"dhcpd-failover"', 'state']
 
     """
-    string = string.split(sep)
-    return [sep.join(string[:pos])] + string[pos:]
+    string = shlex.split(string, posix=False)
+    return [' '.join(string[:pos])] + string[pos:]
 
 
 def event_split(string, event_type):


### PR DESCRIPTION
The parser doesn't correctly deal with tabs as whitespace in some places, such as in this completely legal syntax example:

```
option domain-name\t"example.org";
```
(\t representing an actual tab character)
results in:
``` 
node.type='option domain-name\t"example.org\"'
node.value=''
```
instead of the expected:
```
node.type='option domain-name'
node.value='"example.org"'
```

This is because split_at() and split_from() are only ever called with ' ' as a separator, which is passed to string.split().  

The change in this PR uses shlex.split(string,posix=False) which should generally handle mixed whitespace well, while at the same time preserving any specific repeated or mixed whitespace in quoted strings.   Strings are reassembled with a single space (again with original whitespace in quoted strings preserved). This normalization of whitespace also makes it easier to interpret the value of nodes later. 

Because shlex.split() doesn't take an explicit separator to split on, and split_at and split_from are only ever called elsewhere in the package with ' ' as the separator, the sep parameter was removed from the method call.   The existing usages were updated to reflect this. 

Considerations:   shlex (with posix option) has been supported since Python 2.6, which seems reasonable.  The posix=False behavior is what enables the preservation of quotes.   However it doesn't support escape characters or nested quotes, but then neither does ISC.  
