### PR TITLE
Feature: add source line number tracking to parser

### DIFF
--- a/pyisc/dhcpd/parsing.py
+++ b/pyisc/dhcpd/parsing.py
@@ -92,8 +92,11 @@ class DhcpdParser(BaseParser):
         node_stack = []
         splitter = DhcpdSplitter()
         next_comment = None
+        lineno = 1
         for token in self.tokenize(content):
             if token.type in ['whitespace', 'newline']:
+                if token.type == 'newline':
+                    lineno += 1
                 continue
             if token.type == 'section_end':
                 node = node_stack.pop()
@@ -103,16 +106,17 @@ class DhcpdParser(BaseParser):
                 else:
                     next_comment += '\n'
                 next_comment += token.value.strip()
+                lineno += 1
             if token.type.startswith(('parameter', 'expression', 'event')):
                 key, value, parameters, *_ = splitter.switch(token)
                 prop = PropertyNode(
-                    type=key, value=value, parameters=parameters)
+                    type=key, value=value, parameters=parameters, lineno=lineno)
                 prop.comment = next_comment
                 next_comment = None
                 node.children.append(prop)
             if token.type.startswith('declaration'):
                 key, value, parameters, *_ = splitter.switch(token)
-                section = Node(type=key, value=value, parameters=parameters)
+                section = Node(type=key, value=value, parameters=parameters, lineno=lineno)
                 section.comment = next_comment
                 next_comment = None
                 node.children.append(section)

--- a/pyisc/shared/nodes.py
+++ b/pyisc/shared/nodes.py
@@ -83,7 +83,7 @@ class RootNode:
 class Node:
     """Represents an entity capable of having properties."""
 
-    def __init__(self, type=None, value=None, parameters=None, children=None):
+    def __init__(self, type=None, value=None, parameters=None, children=None, lineno=0, filename=None):
         """Initialize attributes for the class.
 
         Args:
@@ -103,6 +103,8 @@ class Node:
         self.children = [] if not children else children
         self.parameters = parameters
         self.comment = None
+        self.lineno = lineno
+        self.filename = filename
 
     def __eq__(self, other):
         """Return boolean value from comparison with other object."""
@@ -159,7 +161,7 @@ class Node:
 class PropertyNode:
     """Represents a property of a node."""
 
-    def __init__(self, type=None, value=None, parameters=None):
+    def __init__(self, type=None, value=None, parameters=None, lineno=0, filename=None):
         """Initialize attributes for the class.
 
         Args:
@@ -173,6 +175,8 @@ class PropertyNode:
         self.value = value
         self.parameters = parameters
         self.comment = None
+        self.lineno = lineno
+        self.filename = filename
 
     def __eq__(self, other):
         """Return boolean value from comparison with other object."""


### PR DESCRIPTION
After parsing a DHCP configuration, it would be useful to have a reference to the location in the source text that the node was instantiated from.   For example, one might want to display a message about a configuration detail that doesn't meet some criteria, or look at the original file to determine why something was not parsed correctly.    It is trivial to locate this when the input text is only a handful of lines long, but harder when the file is much longer.

The proposed change in this PR, adds line number tracking.  Specifically:

in dhcp/parsing.py, a line number counter is added that increments on newline or comment tokens (either of which consume newlines from the source text)  This is passed to the Node and Property node constructors as an optional named parameter.  

in shared/nodes.py, the Node and PropertyNode classes now include a 'lineno' property, which can optionally be passed in the constructor by the parser.   Defaults to 0 if not set.  

A 'filename' property and optional constructor parameter are also added to the nodes for _future_ parser enhancement that could read from files (where DHCP config is typically stored) directly... and which could handle include files, thus some nodes could have a different source file.   (the parser would have to keep track of the line numbers separately for included files) Defaults to None if not set.

Tested for line number accuracy on various points in a ~5K line config file.

Thank you for considering.